### PR TITLE
Use ScanCodes instead of KeyCodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ leafwing-input-manager = { version = "0.9", optional = true }
 
 [dependencies.bevy]
 version = "0.10"
-features = ["bevy_render", "bevy_asset"]
+features = ["bevy_render", "bevy_asset", "bevy_pbr"]
 default-features = false
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -94,4 +94,9 @@ There is a bunch of other bevy camera controllers that are worth checking out, e
 The project is under dual license MIT and Apache 2.0, so joink to your hearts content, just remember the license agreements.
 
 ## Contributing
-Yes this project is still very much WIP, so PRs are very welcome
+
+Yes this project is still very much WIP, so PRs are very welcome.  
+The `dolly` dependency used is a slightly patched submodule, so to build the crate locally you must first run the following:  
+```bash
+git submodule update --init --recursive
+```

--- a/src/helpers/cursor_grab.rs
+++ b/src/helpers/cursor_grab.rs
@@ -2,10 +2,7 @@ use bevy::{
     prelude::*,
     window::{CursorGrabMode, PrimaryWindow},
 };
-use leafwing_input_manager::{
-    prelude::{ActionState, InputMap},
-    Actionlike, InputManagerBundle,
-};
+use leafwing_input_manager::prelude::*;
 
 pub struct DollyCursorGrab;
 impl Plugin for DollyCursorGrab {
@@ -59,7 +56,7 @@ impl Default for DollyCursorGrabInputBundle {
         use GrabAction::*;
         let mut input_map = InputMap::default();
 
-        input_map.insert(KeyCode::Escape, Exit);
+        input_map.insert(QwertyScanCode::Escape, Exit);
 
         let input_manager = InputManagerBundle {
             input_map,

--- a/src/helpers/pos_ctrl.rs
+++ b/src/helpers/pos_ctrl.rs
@@ -131,45 +131,45 @@ impl Default for DollyPosCtrlInputBundle {
         //TODO: Impl. when added to input-manager
         //input_map.assign_gamepad(Gamepad(0));
 
-        input_map.insert(KeyCode::W, Forward);
-        input_map.insert(KeyCode::Up, Forward);
+        input_map.insert(QwertyScanCode::W, Forward);
+        input_map.insert(QwertyScanCode::Up, Forward);
 
         input_map.insert(GamepadButtonType::DPadUp, Forward);
         //input_map.insert(SingleAxis::symmetric(GamepadAxisType::LeftStickY, 0.1), Forward); // + Y / - Y
 
-        input_map.insert(KeyCode::S, Backward);
-        input_map.insert(KeyCode::Down, Backward);
+        input_map.insert(QwertyScanCode::S, Backward);
+        input_map.insert(QwertyScanCode::Down, Backward);
         input_map.insert(GamepadButtonType::DPadDown, Backward);
 
-        input_map.insert(KeyCode::A, StrafeLeft);
-        input_map.insert(KeyCode::Left, StrafeLeft);
+        input_map.insert(QwertyScanCode::A, StrafeLeft);
+        input_map.insert(QwertyScanCode::Left, StrafeLeft);
         input_map.insert(GamepadButtonType::DPadLeft, StrafeLeft);
 
-        input_map.insert(KeyCode::D, StrafeRight);
-        input_map.insert(KeyCode::Right, StrafeRight);
+        input_map.insert(QwertyScanCode::D, StrafeRight);
+        input_map.insert(QwertyScanCode::Right, StrafeRight);
         input_map.insert(GamepadButtonType::DPadRight, StrafeRight);
 
         //input_map.insert(SingleAxis::symmetric(GamepadAxisType::LeftStickX, 0.1), StrafeRight); // + X / - X
 
-        input_map.insert(KeyCode::Space, Up);
+        input_map.insert(QwertyScanCode::Space, Up);
         input_map.insert(
             SingleAxis::positive_only(GamepadAxisType::LeftStickY, 0.1),
             Up,
         );
 
-        input_map.insert(KeyCode::LShift, Down);
+        input_map.insert(QwertyScanCode::LShift, Down);
         input_map.insert(
             SingleAxis::negative_only(GamepadAxisType::LeftStickY, 0.1),
             Down,
         );
 
-        input_map.insert(KeyCode::Comma, RotateLeft);
+        input_map.insert(QwertyScanCode::Comma, RotateLeft);
         input_map.insert(
             SingleAxis::negative_only(GamepadAxisType::LeftStickX, 0.1),
             RotateLeft,
         );
 
-        input_map.insert(KeyCode::Period, RotateRight);
+        input_map.insert(QwertyScanCode::Period, RotateRight);
         input_map.insert(
             SingleAxis::positive_only(GamepadAxisType::LeftStickX, 0.1),
             RotateRight,


### PR DESCRIPTION
- Fix #26. There are still KeyCodes left, but they are in places where LWIM is not used, so platform independence is not trivial there. I suggest moving these instances to LWIM in the future.
- Fix non dev builds failing because `PbrBundle` and `StandardMaterial` require the `bevy/bevy_pbr` feature
- Mention submodule in readme.
